### PR TITLE
ndarray switch to discriminating union

### DIFF
--- a/src/p4p/nt/ndarray.py
+++ b/src/p4p/nt/ndarray.py
@@ -63,12 +63,39 @@ class NTNDArray(object):
     Value = Value
     ntndarray = ntndarray
 
+    # map numpy.dtype.char to .value union member name
+    _code2u = {
+        '?':'booleanValue',
+        'b':'byteValue',
+        'h':'shortValue',
+        'i':'intValue',
+        'l':'longValue',
+        'B':'ubyteValue',
+        'H':'ushortValue',
+        'I':'uintValue',
+        'L':'ulongValue',
+        'f':'floatValue',
+        'd':'doubleValue',
+    }
+
     @staticmethod
     def buildType(extra=[]):
         """Build type
         """
         return Type([
-            ('value', 'v'),
+            ('value', ('U', None, [
+                ('booleanValue', 'a?'),
+                ('byteValue', 'ab'),
+                ('shortValue', 'ah'),
+                ('intValue', 'ai'),
+                ('longValue', 'al'),
+                ('ubyteValue', 'aB'),
+                ('ushortValue', 'aH'),
+                ('uintValue', 'aI'),
+                ('ulongValue', 'aL'),
+                ('floatValue', 'af'),
+                ('doubleValue', 'ad'),
+            ])),
             ('alarm', alarm),
             ('timeStamp', timeStamp),
             ('dimension', ('aS', None, [
@@ -97,7 +124,7 @@ class NTNDArray(object):
         # else: assume caller knows what ColorMode means
 
         return Value(self.type, {
-            'value': value.flatten(),
+            'value': (self._code2u[value.dtype.char], value.flatten()),
             'timeStamp': {
                 'secondsPastEpoch': S,
                 'nanoseconds': NS * 1e9,

--- a/src/p4p/test/test_nt.py
+++ b/src/p4p/test/test_nt.py
@@ -303,10 +303,10 @@ class TestArray(RefTestCase):
 
            [[12, 13, 14, 15],
             [16, 17, 18, 19],
-            [20, 21, 22, 23]]])
+            [20, 21, 22, 23]]], dtype='u1')
 
         V = Value(nt.NTNDArray.buildType(), {
-            'value': numpy.arange(24),
+            'value': ('ubyteValue', numpy.arange(24, dtype='u1')),
             'dimension': [
                 {'size': 4}, # X, columns
                 {'size': 3}, # Y, rows
@@ -316,11 +316,13 @@ class TestArray(RefTestCase):
                 {'name': 'ColorMode', 'value': 4},
             ],
         })
+        self.assertEqual(V.value.dtype, pixels.dtype)
 
         img = nt.NTNDArray.unwrap(V)
 
         self.assertEqual(img.shape, (2, 3, 4))
         assert_aequal(img, pixels)
+        self.assertEqual(img.dtype, pixels.dtype)
 
         V2 = nt.NTNDArray().wrap(img)
 
@@ -328,3 +330,4 @@ class TestArray(RefTestCase):
         self.assertEqual(V.dimension[0].size, V2.dimension[0].size)
         self.assertEqual(V.dimension[1].size, V2.dimension[1].size)
         self.assertEqual(V.dimension[2].size, V2.dimension[2].size)
+        self.assertEqual(V2.value.dtype, pixels.dtype)


### PR DESCRIPTION
Partly in response to #24.  Though not directly a fix (that is 7f127405acb03d39f9cf3bed57dd5d3ee79a31c7).  Switch `.value` from a variant union (aka. any) to a discriminating/tagged union.  This prevents situations like `V.value = V`, thus moving errors like that seen with #24 to the client side, which should make the cause more obvious.

I don't think this will break users of the `p4p.nt.ndarray.ntndarray` wrapper, but does change the type definition in a way likely to break server side users directly calling `p4p.nt.ndarray.NTNDArray.buildType()` (I'm not sure if there are any).

This will conflict with #23, but this should be easily resolved as there is no actual overlap.

@tynanford fyi @ddamiani Can you retest with this branch?