### PR TITLE
Make NTEnum useful

### DIFF
--- a/src/p4p/client/raw.py
+++ b/src/p4p/client/raw.py
@@ -94,7 +94,7 @@ def monHandler(handler):
     return cb
 
 
-def defaultBuilder(value):
+def defaultBuilder(value, nt):
     """Reasonably sensible default handling of put builder
     """
     if callable(value):
@@ -114,7 +114,7 @@ def defaultBuilder(value):
                 for k, v in value.items():
                     V[k] = v
             else:
-                V.value = value
+                nt.assign(V, value)
         except:
             _log.exception("Exception in Put builder")
             raise  # will be printed to stdout from extension code.
@@ -278,7 +278,8 @@ class Context(object):
         """
         chan = self._channel(name)
         return _p4p.ClientOperation(chan, handler=unwrapHandler(handler, self._nt),
-                                    builder=defaultBuilder(builder), pvRequest=wrapRequest(request), get=get, put=True)
+                                    builder=defaultBuilder(builder, self._nt),
+                                    pvRequest=wrapRequest(request), get=get, put=True)
 
     def rpc(self, name, handler, value, request=None):
         """Perform RPC operation on PV

--- a/src/p4p/nt/__init__.py
+++ b/src/p4p/nt/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
 _default_nt = {
     "epics:nt/NTScalar:1.0": NTScalar,
     "epics:nt/NTScalarArray:1.0": NTScalar,
+    "epics:nt/NTEnum:1.0": NTEnum,
     "epics:nt/NTNDArray:1.0": NTNDArray,
 }
 

--- a/src/p4p/nt/enum.py
+++ b/src/p4p/nt/enum.py
@@ -3,7 +3,31 @@ from __future__ import absolute_import
 
 from ..wrapper import Type, Value
 from .common import alarm, timeStamp
-from .scalar import _metaHelper
+from .scalar import _metaHelper, ntwrappercommon
+
+class ntenum(ntwrappercommon, int):
+    """
+
+    * .severity
+    * .status
+    * .timestamp - Seconds since 1 Jan 1970 UTC as a float
+    * .raw_stamp - A tuple (seconds, nanoseconds)
+    * .raw - The underlying :py:class:`p4p.Value`.
+    """
+
+    def _store(self, value):
+        ntwrappercommon._store(self, value)
+        self.choice = None
+
+        return self
+
+    def __str__(self):
+        return self.choice or int.__str__(self)
+
+    def __repr__(self):
+        return '%s(%d, %s)'%(self.__class__.__name__, int(self), self.choice)
+
+    # TODO: compare with str
 
 class NTEnum(object):
     """Describes a string selected from among a list of possible choices.  Stored internally as an integer
@@ -18,14 +42,52 @@ class NTEnum(object):
             ('alarm', alarm),
             ('timeStamp', timeStamp),
         ]
+        # TODO: different metadata options
         _metaHelper(F, 'i', display=display, control=control, valueAlarm=valueAlarm)
         F.extend(extra)
         return Type(id="epics:nt/NTEnum:1.0", spec=F)
 
     def __init__(self, **kws):
         self.type = self.buildType(**kws)
+        # cached choices list.
+        # picked up during unwrap
+        self._choices = []
 
     def wrap(self, value):
         """Pack python value into Value
         """
-        return Value(self.type, {'value': value})
+        V = self.type()
+        if isinstance(value, dict):
+            # assume dict of index and choices list
+            V.value = value
+            self._choices = V['value.choices']
+        else:
+            # index or string
+            self.assign(V, value)
+        return V
+
+    def unwrap(self, value):
+        """Unpack a Value into an augmented python type (selected from the 'value' field)
+        """
+        if value.changed('value.choices'):
+            self._choices = value['value.choices']
+
+        idx = value['value.index']
+        ret = ntenum(idx)._store(value)
+        try:
+            ret.choice = self._choices[idx]
+        except IndexError:
+            pass # leave it as None
+        return ret
+
+    def assign(self, V, py):
+        """Store python value in Value
+        """
+        if isinstance(py, (bytes, unicode)):
+            for i,C in enumerate(V['value.choices'] or self._choices):
+                if py==C:
+                    V['value.index'] = i
+                    return
+
+        # attempt to parse as integer
+        V['value.index'] = py

--- a/src/p4p/nt/ndarray.py
+++ b/src/p4p/nt/ndarray.py
@@ -115,3 +115,8 @@ class NTNDArray(object):
             # Union empty.  treat as zero-length char array
             V = numpy.zeros((0,), dtype=numpy.uint8)
         return V.view(klass.ntndarray)._store(value)
+
+    def assign(self, V, py):
+        """Store python value in Value
+        """
+        V.value = py

--- a/src/p4p/nt/scalar.py
+++ b/src/p4p/nt/scalar.py
@@ -215,6 +215,11 @@ class NTScalar(object):
         except Exception as e:
             raise ValueError("Can't construct %s around %s (%s): %s" % (T, value, type(value), e))
 
+    def assign(self, V, py):
+        """Store python value in Value
+        """
+        V.value = py
+
 if sys.version_info < (3, 0):
     class ntlong(ntwrappercommon, long):
         pass


### PR DESCRIPTION
A rather involved change to the NT wrapper interface in order to make NTEnum useful (#25).

Mainly a replacement/extension of the client side wrapper functions with a stateful wrap/unwrap object.  This allows `p4p.nt.enum.NTEnum` to cache a choices list, allowing for index lookup in `wrap()` and `unwrap()` where it might not otherwise be available.

This is really a workaround for the race conditions inherent in the way PVA protocol and the NTEnum are defined.

The `p4p.nt.enum.ntenum` wrapper acts like an integer, with an additional member `choice` containing the string (if known).

There are still some TODOs here.  I wonder if the wrapper object should be compatible with `str`?

@tynanford Would this work for you?  Improvements?

Server side usage would be:

```py
from p4p.nt import NTEnum
from p4p.server.thread import SharedPV
pv = SharedPV(nt=NTEnum(), initial={'choices':['zero','one'], 'index':1})
assert pv.current()==1, pv.current() # compare ntenum with int
print pv.current() # prints "one\n"

pv.post(0) # as integer
assert pv.current()==0 # compare ntenum with int

pv.post(1) # as string
assert pv.current()==1

# change choices list
pv.post({'choices':['A','B','C'], 'index':2})
assert pv.current()==2
```

Client side usage against QSRV w/ an mbboRecord

```
record(mbbo, "select") {
    field(ZRVL, "0")
    field(ONVL, "1")
    field(ZRST, "Zero")
    field(ONST, "One")
}
```

would be

```py
from p4p.client.thread import Context
ctxt=Context('pva')
print repr(ctxt.get('select'))
# "ntenum(0, Zero)\n"
ctxt.put('select', 1)
print repr(ctxt.get('select'))
# "ntenum(1, One)\n"
ctxt.put('select', 'Zero')
print repr(ctxt.get('select'))
# "ntenum(0, Zero)\n"
```

Documentation of this new NT interface is tbd.