### PR TITLE
fix for getting and putting lists of pvs in the asyncio client

### DIFF
--- a/src/p4p/client/asyncio.py
+++ b/src/p4p/client/asyncio.py
@@ -140,7 +140,7 @@ class Context(raw.Context):
 
         futs = [self._get_one(N, request=R) for N, R in zip(name, request)]
 
-        ret = yield from asyncio.gather(futs, loop=self.loop)
+        ret = yield from asyncio.gather(*futs, loop=self.loop)
 
         return ret
 
@@ -210,7 +210,7 @@ class Context(raw.Context):
 
         futs = [self._put_one(N, V, request=R, get=get) for N, V, R in zip(name, values, request)]
 
-        yield from asyncio.gather(futs, loop=self.loop)
+        yield from asyncio.gather(*futs, loop=self.loop)
 
     @asyncio.coroutine
     def _put_one(self, name, value, request=None, get=True):


### PR DESCRIPTION
I found a bug when passing a list a pvs to either get or put when using the asyncio version of the client. If you do that it gives the following traceback:

`
Traceback (most recent call last):
  File "async.py", line 9, in <module>
    print(loop.run_until_complete(ctx.get(pvs)))
  File "/u1/ddamiani/miniconda3/envs/amii/lib/python3.6/asyncio/base_events.py", line 473, in run_until_complete
    return future.result()
  File "/u1/ddamiani/p4p_tests/test_install/p4p/client/asyncio.py", line 143, in get
    ret = yield from asyncio.gather(futs, loop=self.loop)
  File "/u1/ddamiani/miniconda3/envs/amii/lib/python3.6/asyncio/tasks.py", line 600, in gather
    for arg in set(coros_or_futures):
TypeError: unhashable type: 'list'
`

The issue is that asyncio.gather expects *args instead of a sequence of futures/coroutines (unlike asyncio.wait for some reason....).

