### PR TITLE
add small multiple field put example to doc

### DIFF
--- a/documentation/client.rst
+++ b/documentation/client.rst
@@ -38,6 +38,7 @@ Get and Put operations can be performed on single PVs or a list of PVs. ::
    >>> A, B = ctxt.get(['pv:1', 'pv:2'])
    >>> ctxt.put('pv:name', 5)
    >>> ctxt.put('pv:name', {'value': 5}) # equivalent to previous
+   >>> ctxt.put('pv:name', {'field_1.value': 5, 'field_2.value': 5}) # put to multiple fields
 
 By default the values returned by :py:meth:`Context.get` are subject to :py:ref:`unwrap`.
 


### PR DESCRIPTION
Just adds an extra put example to the client documentation.