### PR TITLE
add ntbool support to NTScalar automatic value unwrapping

### DIFF
--- a/src/p4p/nt/scalar.py
+++ b/src/p4p/nt/scalar.py
@@ -25,8 +25,7 @@ class ntwrappercommon(object):
         return self
 
     def __str__(self):
-        V = super(ntwrappercommon, self).__repr__()
-        return '%s %s' % (time.ctime(self.timestamp), V)
+        return '%s %s' % (time.ctime(self.timestamp), self.__repr__())
 
     tostr = __str__
 
@@ -52,6 +51,23 @@ class ntint(ntwrappercommon, int):
     * .raw_stamp - A tuple (seconds, nanoseconds)
     * .raw - The underlying :py:class:`p4p.Value`.
     """
+
+
+class ntbool(ntwrappercommon, int):
+    """
+    Augmented boolean with additional attributes
+
+    * .severity
+    * .status
+    * .timestamp - Seconds since 1 Jan 1970 UTC as a float
+    * .raw_stamp - A tuple (seconds, nanoseconds)
+    * .raw - The underlying :py:class:`p4p.Value`.
+    """
+    def __new__(cls, value):
+        return int.__new__(cls, bool(value))
+
+    def __repr__(self):
+        return bool(self).__repr__()
 
 
 class ntstr(ntwrappercommon, unicode):
@@ -203,6 +219,7 @@ class NTScalar(object):
             })
 
     typeMap = {
+        bool: ntbool,
         int: ntint,
         float: ntfloat,
         unicode: ntstr,


### PR DESCRIPTION
The default NTScalar unwrapping throws an exception when getting a boolean PV. There isn't an ntbool I assume because bool can't be subclassed? I add an ntbool class that is a subclass of int, but only can have a value of 0 or 1. It's __repr__ also mimics the built-in boolean.

Example of it in action from the client-side
```
In [10]: ctxt.get('demo:pv:n2')                                                                                                                               
Out[10]: True
In [11]: print(ctxt.get('demo:pv:n2'))                                                                                                                        
Thu Apr 11 09:51:48 2019 True
In [12]: ctxt.get('demo:pv:n2').timestamp                                                                                                                     
Out[12]: 1555001508.1798918
In [13]: type(ctxt.get('demo:pv:n2'))                                                                                                                      
Out[13]: p4p.nt.scalar.ntbool
```

Also includes a small edit to the __str__ method of ntwrappercommon so it will use the __repr__ of the nt* class if it has one (like this ntbool does). 