### PR TITLE
rpc method of the asyncio client now returns result of rpc

### DIFF
--- a/src/p4p/client/asyncio.py
+++ b/src/p4p/client/asyncio.py
@@ -270,7 +270,7 @@ class Context(raw.Context):
         op = super(Context, self).rpc(name, cb, value, request=request)
 
         try:
-            value = yield from F
+            return (yield from F)
         finally:
             op.close()
 


### PR DESCRIPTION
The rpc method of p4p.client.asyncio.Context isn't actually returning the value of the response from the rpc operation. It seems it is a simple one line fix - basically a missing return statement.