### PR TITLE
Warn instead of raise exc. for invalid pvlist patterns

### DIFF
--- a/src/p4p/asLib/pvlist.py
+++ b/src/p4p/asLib/pvlist.py
@@ -69,7 +69,11 @@ class PVList(object):
                 pattern, cmd, parts = parts[0], parts[1], parts[2:]
 
                 # test compile
-                C = re.compile(pattern)
+                try:
+                    C = re.compile(pattern)
+                except Exception as e:
+                    _log.warn("line %s: %s, pattern %s"%(lineno, e, pattern))
+                    continue
 
                 if pattern in allow:
                     continue # ignore duplicate pattern

--- a/src/p4p/asLib/pvlist.py
+++ b/src/p4p/asLib/pvlist.py
@@ -72,7 +72,7 @@ class PVList(object):
                 try:
                     C = re.compile(pattern)
                 except Exception as e:
-                    _log.warn("line %s: %s, pattern %s"%(lineno, e, pattern))
+                    _log.error("line %s: %s, pattern %s"%(lineno, e, pattern))
                     continue
 
                 if pattern in allow:


### PR DESCRIPTION
Needed to ensure typos in the frequently updated pvlist patterns
do not kill the gateway.
Also log the line number and invalid content so users can find and
fix problems.

We have many people updating pvlist files for beamlines and while
a typo or syntax error may not accomplish what the person wanted, 
it shouldn't bring down the gateway.