### PR TITLE
pvlist case insensitive keyword comparisons

### DIFF
--- a/src/p4p/asLib/pvlist.py
+++ b/src/p4p/asLib/pvlist.py
@@ -66,7 +66,11 @@ class PVList(object):
                     continue
 
                 parts = [part.strip() for part in line.split(None)]
-                pattern, cmd, parts = parts[0], parts[1], parts[2:]
+                try:
+                    pattern, cmd, parts = parts[0], parts[1].upper(), parts[2:]
+                except:
+                    _log.warn("line %s is invalid:\n%s"%(lineno, line))
+                    continue
 
                 # test compile
                 C = re.compile(pattern)
@@ -75,7 +79,7 @@ class PVList(object):
                     continue # ignore duplicate pattern
 
                 if cmd=='DENY':
-                    if len(parts) and parts[0]=='FROM':
+                    if len(parts) and parts[0].upper()=='FROM':
                         parts = parts[1:]
 
                     if parts:
@@ -110,8 +114,7 @@ class PVList(object):
                     raise RuntimeError("Unknown command: %s"%cmd)
 
             except Exception as e:
-                raise
-                #raise e.__class__("Error on line %s: %s"%(lineno, e))
+                raise e.__class__("Error on line %s: %s\n%s"%(lineno, e, line))
 
         deny_all = list(deny_all)
 

--- a/src/p4p/test/test_asLib.py
+++ b/src/p4p/test/test_asLib.py
@@ -23,10 +23,12 @@ EVALUATION ORDER ALLOW, DENY
 OTRS:DMP1:695:Image:.*     DENY
 PATT:SYS0:1:MPSBURSTCTRL.* ALLOW CANWRITE
 PATT:SYS0:1:MPSBURSTCTRL.* DENY FROM 1.2.3.4 
+PATT:SYS0:1:MPSBURSTCTRL.* DENY From 4.3.2.1
 X(.*) ALIAS Y\1 CANWRITE
 BEAM.* DENY FROM 1.2.3.4   
 BEAM.* ALLOW
 BEAM.* ALLOW RWINSTRMCC 1
+BEAM:L1:.* allow
 
 THIS ALIAS THAT
 
@@ -37,6 +39,7 @@ a:([^:]*):b:([^:]*) ALIAS A:\2:B:\1
         pvl = PVList(pvlist)
 
         self.assertEqual(pvl.compute(b'BEAM:stuff', '127.0.0.1'), ('BEAM:stuff', 'RWINSTRMCC', 1))
+        self.assertEqual(pvl.compute(b'BEAM:L1:Energy', '127.0.0.1'), ('BEAM:L1:Energy', 'DEFAULT', 0))
 
         self.assertEqual(pvl.compute(b'OTHER:stuff', '127.0.0.1'), ('OTHER:stuff', 'DEFAULT', 0))
 
@@ -44,6 +47,7 @@ a:([^:]*):b:([^:]*) ALIAS A:\2:B:\1
 
         self.assertEqual(pvl.compute(b'PATT:SYS0:1:MPSBURSTCTRLX', '127.0.0.1'), ('PATT:SYS0:1:MPSBURSTCTRLX', 'CANWRITE', 0))
         self.assertEqual(pvl.compute(b'PATT:SYS0:1:MPSBURSTCTRLX', '1.2.3.4'), (None, None, None))
+        self.assertEqual(pvl.compute(b'PATT:SYS0:1:MPSBURSTCTRLX', '4.3.2.1'), (None, None, None))
 
         self.assertEqual(pvl.compute(b'Xsomething', '127.0.0.1'), ('Ysomething', 'CANWRITE', 0))
         self.assertEqual(pvl.compute(b'a:one:b:two', '127.0.0.1'), ('A:two:B:one', 'DEFAULT', 0))


### PR DESCRIPTION
Matches CA gateway parsing.
Also make pattern errors log a warning and continue so gateway is not
killed by a typo in the often updated pvlist patterns.
Also show line number and contents in error and warning messages to make
it easier for users to find and fix pvlist issues.