### PR TITLE
ENH: Add ignoreaddr option

### DIFF
--- a/documentation/gw.rst
+++ b/documentation/gw.rst
@@ -182,6 +182,7 @@ A full list of known keys for configuration scheme version 2. ::
                 "clients":["theclient"],
                 "interface":["..."],
                 "addrlist":"",
+                "ignoreaddr":["..."],
                 "autoaddrlist":false,
                 "serverport":5075,
                 "bcastport":5076,
@@ -237,6 +238,9 @@ Keys
 
 **servers[].addrlist** (default: "")
     List of broadcast and unicast addresses to which beacon messages will be sent
+
+**servers[].ignoreaddr** (default: "")
+    List of address to add into the banned list to explicit ignore hosts.
 
 **servers[].autoaddrlist** (default: true)
     Whether to automatically populate *addrlist* with **all** local interface broadcast addresses.

--- a/src/p4p/gw.py
+++ b/src/p4p/gw.py
@@ -625,6 +625,11 @@ class App(object):
             providers = [statusp]
             self.__lifesupport += [statusp]
 
+            # Fetch the list of ignored addresses for this server
+            ignored_addresses = jsrv.get('ignoreaddr') or []
+            if isinstance(ignored_addresses, (unicode, str)):
+                ignored_addresses = [ignored_addresses]
+
             try:
                 for client in jsrv['clients']:
                     pname = u'gws.%s.%s'%(name, client)
@@ -637,6 +642,10 @@ class App(object):
 
                     if not args.test_config:
                         handler.provider = _gw.Provider(pname, client, handler) # implied installProvider()
+
+                    # prevent client from searching on ignored addresses
+                    for addr in ignored_addresses:
+                        handler.provider.forceBan(host=addr.encode('utf-8'))
 
                     self.__lifesupport += [client]
                     self.stats.handlers.append(handler)


### PR DESCRIPTION
Add a new server option `ignoreaddr` to to explicit ignore hosts.
Closes #60 