### PR TITLE
Consistent server naming pattern. i.e. theServer_0, theServer_1, ...

### DIFF
--- a/src/p4p/gw.py
+++ b/src/p4p/gw.py
@@ -565,10 +565,10 @@ class App(object):
                 _log.warning('Each server interface will attempt to send beacons to all destinations')
                 jsrv.pop('addrlist')
 
+            base_name = jsrv['name']
             for idx, iface in enumerate(iface):
                 jsrv = jsrv.copy()
-                if idx!=0:
-                    jsrv['name'] = '%s_%d'%(jsrv['name'], idx)
+                jsrv['name'] = '%s_%d'%(base_name, idx)
                 jsrv['interface'] = iface
 
                 new_servers.append(jsrv)

--- a/src/p4p/test/test_gw.py
+++ b/src/p4p/test/test_gw.py
@@ -273,10 +273,10 @@ class TestHighLevel(RefTestCase):
 
         self._app = TestApp(args)
         self._main = threading.Thread(target=self._app.run, name='GW Main')
-        _log.debug("DS server conf: %s", self._app.servers[u'server1'].conf())
+        _log.debug("DS server conf: %s", self._app.servers[u'server1_0'].conf())
 
         # downstream client
-        self._ds_client = Context('pva', conf=self._app.servers[u'server1'].conf(), useenv=False)
+        self._ds_client = Context('pva', conf=self._app.servers[u'server1_0'].conf(), useenv=False)
 
         self._main.start()
         _log.debug("Exit setUp")


### PR DESCRIPTION
Instead of theServer, theServer_1, theServer_2, ...
Modified test_gw.py to append _0 to server name.

Local SLAC patch produced by @bhill-slac 