### PR TITLE
Reload ASG during runtime

### DIFF
--- a/src/p4p/util.py
+++ b/src/p4p/util.py
@@ -1,4 +1,6 @@
 
+import sys
+import os
 import logging
 _log = logging.getLogger(__name__)
 
@@ -10,10 +12,29 @@ except ImportError:
     from queue import Queue, Full, Empty
 from threading import Thread, Event
 
+
 __all__ = [
+    'readnproc',
     'WorkQueue',
 ]
 
+def readnproc(args, fname, fn, **kws):
+    """ Read the configuration file and call the callback function with the read data.
+    """
+    try:
+        if fname:
+            args._all_config_files.append(fname)
+            with open(fname, 'r') as F:
+                data = F.read()
+        else:
+            data = ''
+        return fn(data, **kws)
+    except IOError as e:
+        _log.error('In "%s" : %s', fname, e)
+        sys.exit(1)
+    except RuntimeError as e:
+        _log.error('In "%s" : %s', fname, e)
+        sys.exit(1)
 
 class WorkQueue(object):
 


### PR DESCRIPTION
Hi @mdavidsaver,

Elaine Chandler and I from the ANL are working on [issue 63](https://github.com/mdavidsaver/p4p/issues/63), which is the ability to reload the access security during the runtime. We were successful in applying the new rules for the new connections. But we are currently struggling with applying the new rules to the existing connections. The idea we have is that we try to get the channels objects and the PV names/peers info from which they were created, and call the `testChannel` again inside the `GWHandler` class in the loop for each of them. But unfortunately, I cannot find a structure where this data is saved.  Can you give us any hints please on how to achieve this? 

I also have a question about supporting new connections.  In the existing changes, we added a new PV `asNew` which calls the [`asNew` method](https://github.com/MaticPogacnik/p4p/blob/asg_reload/src/p4p/gw.py#L453) inside the handler object when a user puts a value to it. Code for the `Engine` and the `PVList` classes were refactored and new `update` ([Engine](https://github.com/MaticPogacnik/p4p/blob/asg_reload/src/p4p/asLib/__init__.py#L76), [PVList](https://github.com/MaticPogacnik/p4p/blob/asg_reload/src/p4p/asLib/pvlist.py#L56)) were added so update can be called at the later stage when the gateway is running to reread the configuration files. Constructors of these two classes accept a path to the configuration file now instead of the content of the files as the string. New `update` methods are also [called from the new `asNew` method](https://github.com/MaticPogacnik/p4p/blob/asg_reload/src/p4p/gw.py#L453), to reload the configuration. I am thinking, should update/compute methods be protected by the locks? Can there potentially be a data race if a new connection is opened while the update is in progress? (I do realize, some tests still need to be adjusted)


Thank you