### PR TITLE
Fix RPC callback name in Qt client

### DIFF
--- a/src/p4p/client/Qt.py
+++ b/src/p4p/client/Qt.py
@@ -236,7 +236,7 @@ class Context(raw.Context):
 
         op = Operation(self._parent, timeout)
         op.result.connect(slot)
-        op._op = super(Context, self).rpc(name, op._result, value, request=request)
+        op._op = super(Context, self).rpc(name, op._resultcb, value, request=request)
         return op
 
     def monitor(self, name, slot, request=None, limitHz=10.0):


### PR DESCRIPTION
RPC calls in the Qt client were broken, because the `Operation._result` (where the value gets stored) was being used as the completion handler, instead of `Operation._resultcb` (which is callable).  Looks like a forgotten remnant of a time where the callable had a different name.