### PR TITLE
asyncio: switch from generator to async coroutine

### DIFF
--- a/src/p4p/server/asyncio.py
+++ b/src/p4p/server/asyncio.py
@@ -1,9 +1,7 @@
 
 import logging
-_log = logging.getLogger(__name__)
 
 from functools import partial
-from weakref import WeakSet
 
 import asyncio
 
@@ -16,39 +14,7 @@ __all__ = (
         'Handler',
 )
 
-@asyncio.coroutine
-def _sync(loop):
-    # wait until any pending callbacks are run
-    evt = asyncio.Event(loop=loop)
-    loop.call_soon(evt.set)
-    yield from evt.wait()
-
-    evt.clear() # reuse
-
-    wait4 = set(loop._SharedPV_handlers) # snapshot of in-progress
-
-    # like asyncio.wait() but non-invasive if further callbacks are added.
-    # eg. like overlapping calls of _sync()
-    # We're abusing the callback chain to avoid creating an Event for
-    # each inprogress Future on the assumption that calls to _sync()
-    # are relatively rare.
-
-    cnt = len(wait4)
-    fut = asyncio.Future(loop=loop)
-
-    def _done(V):
-        nonlocal cnt
-        cnt -= 1
-        if cnt==0 and not fut.cancelled():
-            fut.set_result(None)
-        return V # pass result along
-
-    if cnt==0:
-        fut.set_result(None)
-    else:
-        [W.add_done_callback(_done) for W in wait4]
-
-    yield from fut
+_log = logging.getLogger(__name__)
 
 def _log_err(V):
     if isinstance(V, Exception):
@@ -58,18 +24,21 @@ def _log_err(V):
     return V
 
 
-def _handle(loop, op, M, args):
+def _handle(pv, op, M, args): # callback in asyncio loop
     try:
         _log.debug('SERVER HANDLE %s %s %s', op, M, LazyRepr(args))
         maybeco = M(*args)
         if asyncio.iscoroutine(maybeco):
             _log.debug('SERVER SCHEDULE %s', maybeco)
-            task = loop.create_task(maybeco)
-            task.add_done_callback(_log_err)
-            task._log_destroy_pending = False # hack as we don't currently provide a way to join
+            task = asyncio.create_task(maybeco)
 
-            loop._SharedPV_handlers.add(task) # track in-progress
-        return
+            # we have no good place to join async put()/rpc() handler results
+            # other than SharedPV.close(sync=True) which is both optional,
+            # and potentially far in the future.  So we log and otherwise
+            # discard the result.
+            task.add_done_callback(_log_err)
+            task._SharedPV = pv # mark so _wait_closed() can distinguish
+        return # caller is responsible for op.done()
     except RemoteError as e:
         err = e
     except Exception as e:
@@ -81,17 +50,15 @@ def _handle(loop, op, M, args):
 
 class SharedPV(_SharedPV):
 
-    def __init__(self, handler=None, loop=None, **kws):
-        self.loop = loop or asyncio.get_event_loop()
+    def __init__(self, handler=None, **kws):
+        self.loop = asyncio.get_running_loop()
         _SharedPV.__init__(self, handler=handler, **kws)
-        self._disconnected = asyncio.Event(loop=self.loop)
+        self._disconnected = asyncio.Event()
         self._disconnected.set()
-        if not hasattr(self.loop, '_SharedPV_handlers'):
-            self.loop._SharedPV_handlers = WeakSet() # holds our in-progress Futures
 
     def _exec(self, op, M, *args):
-        self.loop.call_soon_threadsafe(partial(_handle, self.loop, op, M, args))
-        # 3.5 adds asyncio.run_coroutine_threadsafe()
+        # note than M may be _onFirstConnect or _onLastDisconnect
+        self.loop.call_soon_threadsafe(partial(_handle, self, op, M, args))
 
     def _onFirstConnect(self, _junk):
         self._disconnected.clear()
@@ -99,10 +66,30 @@ class SharedPV(_SharedPV):
     def _onLastDisconnect(self, _junk):
         self._disconnected.set()
 
-    @asyncio.coroutine
-    def _wait_closed(self):
-        yield from _sync(self.loop)
-        yield from self._disconnected.wait()
+    async def _wait_closed(self):
+        """Wait until any in-progress asynchronous put()/rpc() handler tasks have completed.
+        """
+        _log.debug("Synchronizing %r", self)
+
+        def _peak_done(F, V):
+            F.set_result(V)
+            return V
+
+        Ts = []
+        for t in asyncio.all_tasks():
+            if getattr(t, '_SharedPV', None) is not self:
+                continue
+            F = asyncio.Future()
+            t.add_done_callback(partial(_peak_done, F))
+            Ts.append(F)
+
+        await asyncio.gather(*Ts, return_exceptions=True)
+        # ignore any returned exceptions as they have already been logged
+
+        _log.debug("Synchronized %r", self)
+
+        # wait for Disconnect notification as well
+        await self._disconnected.wait()
 
     def close(self, destroy=False, sync=False):
         """Close PV, disconnecting any clients.

--- a/src/p4p/test/test_asyncio.py
+++ b/src/p4p/test/test_asyncio.py
@@ -1,10 +1,10 @@
 import sys
 import unittest
 
-if sys.version_info<(3,4) or sys.version_info>=(3,10):
+if sys.version_info<(3,7):
     class TestDummy(unittest.TestCase):
         def test_asyncio(self):
-            raise unittest.SkipTest("asyncio needs Py >=3.4.  >=3.10 not yet supported")
+            raise unittest.SkipTest("asyncio needs Py >=3.7")
 
 else:
     from .asynciotest import *

--- a/src/p4p/test/utils.py
+++ b/src/p4p/test/utils.py
@@ -2,13 +2,10 @@
 from __future__ import print_function
 
 import logging
-import warnings
-
 import sys
 import gc
 import inspect
 import unittest
-import functools
 import time
 import os
 import tempfile
@@ -23,34 +20,6 @@ from .._p4p import _forceLazy
 _log = logging.getLogger(__name__)
 
 _forceLazy()
-
-try:
-    import asyncio
-except ImportError:
-    pass
-else:
-    # we should never implicitly use the default loop.
-    asyncio.get_event_loop().close()
-    def inloop(fn):
-        """Decorator assumes wrapping method of object with .loop and maybe .timeout
-        """
-        @functools.wraps(fn)
-        def testmethod(self):
-            F = fn(self)
-            if not hasattr(self, 'loop'):
-                self.loop = asyncio.new_event_loop()
-                self.loop.set_debug(True)
-            timeout = getattr(self, 'timeout', None)
-            if timeout is not None:
-                F = asyncio.wait_for(F, timeout, loop=self.loop)
-            self.loop.run_until_complete(F)
-        return testmethod
-
-    def clearloop(self):
-        if hasattr(self, 'loop'):
-            self.loop.close()
-            del self.loop
-
 
 class RefTestMixin(object):
 


### PR DESCRIPTION
Switch from generator to async keyword for asyncio frontends.

cf. #80
