### PR TITLE
asyncio 3.6 compat

### DIFF
--- a/src/p4p/test/test_asyncio.py
+++ b/src/p4p/test/test_asyncio.py
@@ -1,10 +1,10 @@
 import sys
 import unittest
 
-if sys.version_info<(3,7):
+if sys.version_info<(3,6):
     class TestDummy(unittest.TestCase):
         def test_asyncio(self):
-            raise unittest.SkipTest("asyncio needs Py >=3.7")
+            raise unittest.SkipTest("asyncio needs Py >=3.6")
 
 else:
     from .asynciotest import *


### PR DESCRIPTION
Restore py3.6 support for `p4p.client.asyncio` and `p4p.server.asyncio`.  cf. #82