### PR TITLE
cleaning logging output when a program is interrupted

### DIFF
--- a/src/p4p/client/asyncio.py
+++ b/src/p4p/client/asyncio.py
@@ -394,8 +394,12 @@ class Subscription(object):
                             E = Finished()
                             await self._cb(E)
 
+
+        except asyncio.CancelledError:
+            _log.debug("Cancelled Subscription: %s", LazyRepr(self))
         except:
             _log.exception("Error processing Subscription event: %s", LazyRepr(E))
+        finally:
             if self._S is not None:
                 self._S.close()
             self._S = None


### PR DESCRIPTION
When running a program with asyncio.run(), which is now the recommended way to do it, and the execution is interrupted (e.g., with KeyboardInterrupt), then all tasks are cancelled (https://github.com/python/cpython/blob/3.10/Lib/asyncio/runners.py#L47).
With this PR the idea is to get a cleaner output when interrupting a program, which can be quite verbose with many subscriptions.