### PR TITLE
gw: fix use of "current" before initial upstream update

### DIFF
--- a/src/pvxs_gw.h
+++ b/src/pvxs_gw.h
@@ -40,6 +40,7 @@ struct GWSubscription {
 
     enum state_t {
         Connecting, // waiting for onInit()
+        Connected,  // waiting for first event
         Running,
         Error,
     } state = Connecting;


### PR DESCRIPTION
Candidate fix for #104