### PR TITLE
Add Python 3.11 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -127,7 +127,7 @@ jobs:
             os: ubuntu-latest
             pyver: cp311-cp311
             piparch: manylinux2014_x86_64
-            numpy: numpy==1.22.0
+            numpy: numpy==1.23.5
             cython: Cython==0.29.23
 
           # Linux py builds x64
@@ -236,7 +236,7 @@ jobs:
             os: macos-latest
             python: "3.11"
             piparch: macosx_10_9_intel
-            numpy: numpy==1.22.0
+            numpy: numpy==1.23.5
             cython: Cython==0.29.23
 
           # Windows py builds


### PR DESCRIPTION
This PR adds Python 3.11 to the build matrix, following the same pattern as previous releases.

Note that I didn't add a linux i686 version, as it was already missing a Python 3.10 build.

I also note a subtle difference between this and a similar PR I made on epicscorelibs: The `piparch` value here seems different - in p4p it always has the same value `macosx_10_9_intel` but in epicscorelibs its value changes to `macosx_10_10_intel` for Python 3.10. I don't understand the significance of this, so have simply followed the apparent respective pattern in both places.