### PR TITLE
Update pvxs_gw.cpp to properly block RPC call

### DIFF
--- a/src/pvxs_gw.cpp
+++ b/src/pvxs_gw.cpp
@@ -154,7 +154,7 @@ void GWChan::onRPC(const std::shared_ptr<GWChan>& pv, std::unique_ptr<server::Ex
     log_debug_printf(_log, "'%s' RPC %s\n", sop->name().c_str(), permit ? "begin" : "DENY");
 
     if(!permit) {
-        op->error("RPC permission denied by gateway");
+        sop->error("RPC permission denied by gateway");
         return;
     }
 


### PR DESCRIPTION
The universal reference to unique_ptr "op" was moved to "sop", but op was still used as a pointer, causing segfault.  A call to op->error was changed to sop->error to fix the problem.