### PR TITLE
Fixed build for Python 3.12 and added to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,6 @@ jobs:
       # used by .ci/build-deps.sh for Make builds
       BRBASE: ${{ matrix.base }}
       BRPVXS: ${{ matrix.pvxs }}
-      # cf. https://github.com/numpy/numpy/issues/22623
-      SETUPTOOLS_USE_DISTUTILS: stdlib
     strategy:
       fail-fast: false
       matrix:
@@ -111,6 +109,14 @@ jobs:
             piparch: manylinux2014_x86_64
             numpy: numpy==1.23.5
             cython: Cython==0.29.35
+            skip_cothread: yes
+
+          - name: linux 3.12 amd64
+            os: ubuntu-latest
+            pyver: cp312-cp312
+            piparch: manylinux2014_x86_64
+            numpy: numpy==1.26.1
+            cython: Cython==0.29.36
             skip_cothread: yes
 
           # Linux py builds x64
@@ -216,6 +222,14 @@ jobs:
             cython: Cython==0.29.35
             skip_cothread: yes
 
+          - name: osx 3.12 intel
+            os: macos-latest
+            python: "3.12"
+            piparch: macosx_10_9_intel
+            numpy: numpy==1.26.1
+            cython: Cython==0.29.36
+            skip_cothread: yes
+
           # Windows py builds
 
           ## missing Microsoft Visual C++ 9.0
@@ -268,6 +282,13 @@ jobs:
           - name: win64 3.11
             os: windows-latest
             python: "3.11"
+            piparch: win_amd64
+            profile: latest
+            skip_cothread: yes
+
+          - name: win64 3.12
+            os: windows-latest
+            python: "3.12"
             piparch: win_amd64
             profile: latest
             skip_cothread: yes
@@ -360,7 +381,6 @@ jobs:
           python -m pip install p4p*.whl
           python -m ci_core_dumper exec python -m nose2 -v p4p
 
-
       - name: Docker PY build
         if: matrix.pyver && !matrix.base && !matrix.source
         run: |
@@ -372,7 +392,6 @@ jobs:
           [ -d dist ]
           ls dist/*
           export PATH="/opt/python/${{ matrix.pyver }}/bin:\$PATH"
-          export SETUPTOOLS_USE_DISTUTILS=stdlib
           which python
           python -m pip install -U pip
           python -m pip install setuptools wheel nose2

--- a/makehelper.py
+++ b/makehelper.py
@@ -33,11 +33,16 @@ libdir = get_config_var('LIBDIR') or ''
 
 have_np='NO'
 try:
-    from numpy.distutils.misc_util import get_numpy_include_dirs
-    incdirs = get_numpy_include_dirs()+incdirs
+    from numpy import get_include
+    incdirs.append(get_include())
     have_np='YES'
 except ImportError:
-    pass
+    try:
+        from numpy.distutils.misc_util import get_numpy_include_dirs
+        incdirs = get_numpy_include_dirs()+incdirs
+        have_np='YES'
+    except ImportError:
+        pass
 
 print('TARGET_CFLAGS +=',get_config_var('BASECFLAGS'), file=out)
 print('TARGET_CXXFLAGS +=',get_config_var('BASECFLAGS'), file=out)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,17 @@ import sysconfig
 from setuptools_dso import Extension, setup, cythonize
 
 import numpy
-from numpy.distutils.misc_util import get_numpy_include_dirs
+
+numpy_include_dirs = []
+try:
+    # For numpy >1.23.0 in python 3.12
+    from numpy import get_include
+    numpy_include_dirs = [get_include()]
+except ImportError:
+    from numpy.distutils.misc_util import get_numpy_include_dirs
+    numpy_include_dirs = get_numpy_include_dirs()
+
+
 
 import epicscorelibs.path
 import epicscorelibs.version
@@ -56,7 +66,7 @@ exts = cythonize([
             "src/pvxs_type.cpp",
             "src/pvxs_value.cpp",
         ],
-        include_dirs = get_numpy_include_dirs()+[epicscorelibs.path.include_path, pvxslibs.path.include_path, 'src', 'src/p4p'],
+        include_dirs = numpy_include_dirs + [epicscorelibs.path.include_path, pvxslibs.path.include_path, 'src', 'src/p4p'],
         define_macros = cppflags + [
             ('PY_ARRAY_UNIQUE_SYMBOL', 'PVXS_PyArray_API'),
             ('PVXS_ENABLE_EXPERT_API', None),
@@ -75,7 +85,7 @@ exts = cythonize([
             'src/pvxs_gw.cpp',
             'src/pvxs_odometer.cpp'
         ],
-        include_dirs = get_numpy_include_dirs()+[epicscorelibs.path.include_path, pvxslibs.path.include_path, 'src', 'src/p4p'],
+        include_dirs = numpy_include_dirs + [epicscorelibs.path.include_path, pvxslibs.path.include_path, 'src', 'src/p4p'],
         define_macros = cppflags + [('PVXS_ENABLE_EXPERT_API', None)],
         extra_compile_args = get_config_var('CXXFLAGS')+cxxflags,
         extra_link_args = get_config_var('LDFLAGS')+ldflags,


### PR DESCRIPTION
This fixes the build for Python 3.12. Note that I haven't done extensive testing of `p4p` in 3.12, just got the build working.

Main change was that `get_numpy_include_dirs` is now replaced with `numpy.get_include`. These have been replaced with a preference for the newer version.

Also found that `SETUPTOOLS_USE_DISTUTILS=stdlib` was breaking 3.12 builds. Removing it seemed to cause no build issues but if this is wrong please let me know. 