### PR TITLE
gw: fix config and systemd example generation

### DIFF
--- a/documentation/gw.rst
+++ b/documentation/gw.rst
@@ -16,7 +16,7 @@ The following commands will set up a gateway instance named ``mygw`` on a Linux 
     sudo python -m p4p.gw --example-config /etc/pvagw/mygw.conf
       # generate a systemd unit file to support the gateway
     sudo python -m p4p.gw --example-systemd \
-         /etc/systemd/system/pvagw@.service
+         /etc/systemd/system/pvagw@mygw.service
       # start the gateway
     sudo systemctl daemon-reload
     sudo systemctl start pvagw@mygw.service

--- a/src/p4p/gw.py
+++ b/src/p4p/gw.py
@@ -745,21 +745,28 @@ def main(args=None):
     args = getargs().parse_args(args)
 
     catfile = None
+    conf = '/etc/pvagw/%i.conf'
+    I = '%i'
     if args.example_config:
         catfile = 'example.conf'
+        I = os.path.splitext(os.path.basename(args.config))[0]
+        conf = os.path.abspath(args.config)
     elif args.example_systemd:
         catfile = 'pvagw@.service'
+        inst = os.path.splitext(os.path.basename(args.config))[0].split('@')
+        if len(inst) == 2 and inst[1]:
+            I = inst[1]
+        conf = '/etc/pvagw/{0}.conf'.format(I)
 
     if catfile is not None:
         if args.config=='-':
             O = sys.stdout
-            I = '%i'
-            conf = '/etc/pvagw/%i.conf'
-            print('# eg. save as /etc/systemd/system/pvagw@.service', file=sys.stderr)
+            if args.example_config:
+                print('# eg. save as /etc/pvagw/<instance>.conf', file=sys.stderr)
+            elif args.example_systemd:
+                print('# eg. save as /etc/systemd/system/pvagw@<instance>.service', file=sys.stderr)
         else:
             O = open(args.config, 'w')
-            I = os.path.splitext(os.path.basename(args.config))[0]
-            conf = os.path.abspath(args.config)
 
         pythonpath=os.environ.get('PYTHONPATH','').split(os.pathsep)
         modroot = os.path.dirname(os.path.dirname(__file__)) # directory containing p4p/gw.py


### PR DESCRIPTION
The generation of example configuration and systemd files was a bit messed up:
- systemd service was starting `pvagw` with itself (instead of the config file)
- Parsing the instance name from the command line was broken for the systemd file generation
- Because of this, the systemd file name suggested when printing to "-" was wrong
- Printing to "-" was suggesting to save the config file as systemd file
- In the documentation, the suggested name for the systemd file was wrong