### PR TITLE
Fix handling of multiple DynamicProvider

### DIFF
--- a/src/p4p/server/__init__.py
+++ b/src/p4p/server/__init__.py
@@ -205,8 +205,9 @@ class DynamicProvider(_DynamicProvider):
                 def testChannel(self, name): # return True, False, or DynamicProvider.NotYet
                     return name=="blah"
                 def makeChannel(self, name, peer):
-                    assert name=="blah"
-                    return self.pv
+                    if name=="blah":
+                        return self.pv
+                    # return None falls through to next source
             provider = DynamicProvider("arbitrary", DynHandler())
             server = Server(providers=[provider])
     """

--- a/src/pvxs_source.cpp
+++ b/src/pvxs_source.cpp
@@ -111,11 +111,14 @@ public:
             PyErr_Print();
             PyErr_Clear();
 
+        } else if(ret.obj==Py_None) {
+            // This source will not provide.
+
         } else if(auto pv = SharedPV_unwrap(ret.obj)) {
             pv.attach(std::move(op));
 
         } else {
-            PyErr_Format(PyExc_TypeError, "makeChannel(\"%s\") must return SharedPV, not %s",
+            PyErr_Format(PyExc_TypeError, "makeChannel(\"%s\") must return SharedPV or None, not %s",
                          op->name().c_str(),
                          Py_TYPE(ret.obj)->tp_name);
             PyErr_Print();


### PR DESCRIPTION
Attempt to fix #133.

Currently CI fails for py2.7 for unknown reasons, and the non-docker builds for unrelated distutils reasons.