### PR TITLE
release GIL on pvxs calls

### DIFF
--- a/src/p4p/_p4p.pyx
+++ b/src/p4p/_p4p.pyx
@@ -608,13 +608,15 @@ cdef class ClientProvider:
         cdef server.Config_defs_t defs
 
         if useenv:
-            cconf.applyEnv()
+            with nogil:
+                cconf.applyEnv()
 
         if conf is not None:
             for K,V in conf.items():
                 defs[K.encode()] = V.encode()
 
-            cconf.applyDefs(defs)
+            with nogil:
+                cconf.applyDefs(defs)
 
         with nogil:
             self.ctxt = cconf.build()


### PR DESCRIPTION
previously GIL was not released when calling some pvxs functions, which resulted in potential deadlocks withh other threads. especially it was experienced with EPICS_PVA_ADDR_LIST variable defined when there was a problem with host resolution. more info in MR description

the minimal reproductible example to show where the deadlocks are happening is:

```sh
export EPICS_PVA_ADDR_LIST="epics-gw-lab-01.cslab.esss.lu.se"
```

```python
from p4p.client.thread import Context
import time
from threading import Thread

last_time = time.time()
is_running = True

def run():
    global last_time
    while is_running:
        now = time.time()
        if now > last_time + 1:
            raise Exception(f"It took {now - last_time}")
        last_time = now


thread = Thread(target=run)
thread.start()

times = 0

for i in range(1000):
    c = Context("pva")
    times = times + 1


is_running = False
thread.join(timeout=5)
print(times)
exit()
```

without the changes introduced in this PR, the exception will be raised from the thread. After the changes - the threads will not raise exceptions.

...or maybe there was a reason in the first place that the GIL was not released in those places?