### PR TITLE
server: expose onGet handler callback for demand-driven hardware reads

### DIFF
--- a/documentation/server.rst
+++ b/documentation/server.rst
@@ -37,6 +37,25 @@ A server with a single "mailbox" PV. ::
         'demo:pv:name':pv, # PV name only appears here
     }]) # runs until KeyboardInterrupt
 
+A handler that reads hardware on demand::
+
+    from p4p.nt import NTScalar
+    from p4p.server import Server
+    from p4p.server.thread import SharedPV
+
+    pv = SharedPV(nt=NTScalar('d'), initial=0.0)
+
+    @pv.get
+    def handle_get(pv, op):
+        # Called when a client issues cxt.get(); read hardware here.
+        # op.done() must be called exactly once.
+        value = read_hardware_register()  # application-defined function
+        op.done(value=value)
+
+    Server.forever(providers=[{
+        'demo:pv:name': pv,
+    }])
+
 This server can be tested using the included command line tools. eg. ::
 
     $ python -m p4p.client.cli get demo:pv:name
@@ -172,6 +191,8 @@ SharedPV Handler Interface
     .. automethod:: put
 
     .. automethod:: rpc
+
+    .. automethod:: onGet
 
     .. automethod:: onFirstConnect
 

--- a/src/p4p.h
+++ b/src/p4p.h
@@ -192,6 +192,7 @@ void attachHandler(server::SharedPV& pv, PyObject *handler);
 void detachHandler(server::SharedPV& pv);
 void attachCleanup(const std::shared_ptr<server::ExecOp> &op, PyObject *handler);
 void detachCleanup(const std::shared_ptr<server::ExecOp> &op);
+std::shared_ptr<server::Source> attachGetHandler(const std::string& name, server::SharedPV& pv, PyObject *handler);
 
 std::shared_ptr<server::Source> createDynamic(PyObject* handler);
 void disconnectDynamic(const std::shared_ptr<server::Source>& src);

--- a/src/p4p/_p4p.pyx
+++ b/src/p4p/_p4p.pyx
@@ -42,7 +42,7 @@ cdef extern from "<p4p.h>" namespace "p4p":
     object tostr(const data.Value& v, size_t limit, bool showval) except+
 
     # pvxs_sharedpv.cpp
-    string toString(const server.Server& serv, int detail) except+ nogil
+    string toString(const server.Server& serv, int detail) nogil except+
     void attachHandler(sharedpv.SharedPV& pv, object handler) except+
     void detachHandler(sharedpv.SharedPV& pv) except+
     void attachCleanup(const shared_ptr[source.ExecOp]& op, object handler) except+

--- a/src/p4p/_p4p.pyx
+++ b/src/p4p/_p4p.pyx
@@ -47,6 +47,7 @@ cdef extern from "<p4p.h>" namespace "p4p":
     void detachHandler(sharedpv.SharedPV& pv) except+
     void attachCleanup(const shared_ptr[source.ExecOp]& op, object handler) except+
     void detachCleanup(const shared_ptr[source.ExecOp]& op) except+
+    shared_ptr[server.Source] attachGetHandler(const string& name, sharedpv.SharedPV& pv, object handler) except+
 
     # pvxs_source.cpp
     shared_ptr[server.Source] createDynamic(object) except+
@@ -680,6 +681,7 @@ cdef class Server:
         cdef DynamicProvider dprov
         cdef Source src
         cdef int iorder
+        cdef int gi
 
         if useenv:
             sconf.applyEnv()
@@ -702,6 +704,9 @@ cdef class Server:
                 sprov = prov
                 with nogil:
                     self.serv.addSource(sprov.name, sprov.src.source(), iorder)
+                for gi in range(sprov._get_src_vec.size()):
+                    with nogil:
+                        self.serv.addSource(sprov._get_src_names[gi], sprov._get_src_vec[gi], iorder - 1)
 
             elif isinstance(prov, DynamicProvider):
                 dprov = prov
@@ -932,6 +937,8 @@ cdef class StaticProvider:
     cdef string name
     cdef sharedpv.StaticSource src
     cdef object shadow
+    cdef vector[shared_ptr[server.Source]] _get_src_vec
+    cdef vector[string] _get_src_names
     cdef object __weakref__
 
     def __init__(self, basestring name):
@@ -940,6 +947,7 @@ cdef class StaticProvider:
         self.shadow = {}
 
     def __dealloc__(self):
+        self._get_src_vec.clear()
         with nogil:
             self.src = sharedpv.StaticSource()
 
@@ -949,8 +957,14 @@ cdef class StaticProvider:
 
     def add(self, basestring name, SharedPV pv):
         cdef string cname = name.encode()
-        with nogil:
-            self.src.add(cname, pv.pv)
+        cdef shared_ptr[server.Source] get_src
+        if pv.handler is not None and hasattr(pv.handler, 'onGet'):
+            get_src = attachGetHandler(cname, pv.pv, pv.handler)
+            self._get_src_vec.push_back(get_src)
+            self._get_src_names.push_back(cname)
+        else:
+            with nogil:
+                self.src.add(cname, pv.pv)
         self.shadow[name] = pv
 
     def remove(self, name):

--- a/src/p4p/server/raw.py
+++ b/src/p4p/server/raw.py
@@ -285,6 +285,13 @@ class SharedPV(_SharedPV):
             return fn
         return decorate
 
+    @property
+    def get(self):
+        def decorate(fn):
+            self._handler.onGet = fn
+            return fn
+        return decorate
+
     def __repr__(self):
         if self.isOpen():
             return '%s(value=%s)' % (self.__class__.__name__, repr(self.current()))

--- a/src/p4p/server/raw.py
+++ b/src/p4p/server/raw.py
@@ -40,6 +40,19 @@ class Handler(object):
     Use of this as a base class is optional.
     """
 
+    def onGet(self, pv, op):
+        """
+        Called each time a client issues a Get
+        operation on this Channel.
+
+        :param SharedPV pv: The :py:class:`SharedPV` which this Handler is associated with.
+        :param ServerOperation op: The operation being initiated.
+
+        Call op.done(value=...) to return a value to the client,
+        or op.done(error=...) to signal an error.
+        """
+        op.done(value=pv.current())
+
     def put(self, pv, op):
         """
         Called each time a client issues a Put
@@ -207,6 +220,11 @@ class SharedPV(_SharedPV):
         def __init__(self, pv, real):
             self._pv = pv  # this creates a reference cycle, which should be collectable since SharedPV supports GC
             self._real = real
+            if hasattr(real, 'onGet'):
+                def _onGet(op):
+                    _log.debug('GET %s %s', pv, op)
+                    pv._exec(op, real.onGet, pv, ServOpWrap(op, pv._wrap, pv._unwrap))
+                self.onGet = _onGet
 
         def onFirstConnect(self):
             self._pv._exec(None, self._pv._onFirstConnect, None)

--- a/src/p4p/test/asynciotest.py
+++ b/src/p4p/test/asynciotest.py
@@ -13,13 +13,14 @@ from .utils import RefTestCase
 
 import asyncio
 
-from ..client.asyncio import Context, Disconnected, timesout
+from ..client.asyncio import Context, Disconnected, RemoteError, timesout
 from ..server.asyncio import SharedPV
 
 __all__ = (
     'TestGPM',
     'TestTimeout',
     'TestFirstLast',
+    'TestOnGet',
 )
 
 if sys.version_info < (3, 14):
@@ -273,3 +274,36 @@ class TestFirstLast(AsyncTest):
             finally:
                 sub.close()
                 await sub.wait_closed()
+
+
+class TestOnGet(AsyncTest):
+    timeout = 3.0
+
+    class Handler:
+        async def onGet(self, pv, op):
+            await asyncio.sleep(0)  # yield to prove async dispatch works
+            op.done(value=pv.current())
+
+    async def asyncSetUp(self):
+        await super(TestOnGet, self).asyncSetUp()
+        self.pv = SharedPV(nt=NTScalar('d'), initial=42.0, handler=self.Handler())
+        self.provider = StaticProvider("testget_async")
+        self.provider.add('testget:async', self.pv)
+
+    async def asyncTearDown(self):
+        del self.pv
+        del self.provider
+        await super(TestOnGet, self).asyncTearDown()
+
+    async def test_onget_called(self):
+        with Server(providers=[self.provider], isolate=True) as S:
+            with Context('pva', conf=S.conf(), useenv=False) as C:
+                result = await C.get('testget:async')
+                self.assertAlmostEqual(float(result), 42.0)
+
+    async def test_onget_async(self):
+        # async def onGet with await inside it must work — tests ASIO-02
+        with Server(providers=[self.provider], isolate=True) as S:
+            with Context('pva', conf=S.conf(), useenv=False) as C:
+                result = await C.get('testget:async')
+                self.assertAlmostEqual(float(result), 42.0)

--- a/src/p4p/test/cothreadtest.py
+++ b/src/p4p/test/cothreadtest.py
@@ -245,3 +245,32 @@ class TestFirstLast(RefTestCase):
 
                 _log.debug('CLOSED')
                 self.assertFalse(self.H.conn)
+
+
+class TestOnGet(RefTestCase):
+    timeout = 1.0
+
+    class Handler:
+        def onGet(self, pv, op):
+            cothread.Yield()  # prove we can yield in a cothread callback
+            op.done(value=pv.current())
+
+    def setUp(self):
+        super(TestOnGet, self).setUp()
+        self.pv = SharedPV(nt=NTScalar('d'), initial=42.0, handler=self.Handler())
+        self.provider = StaticProvider("testget_cothread")
+        self.provider.add('testget:coth', self.pv)
+
+    def tearDown(self):
+        del self.pv
+        del self.provider
+        _sync()
+        gc.collect()
+        self.assertSetEqual(set(srv_cothread._handlers), set())
+        super(TestOnGet, self).tearDown()
+
+    def test_onget_called(self):
+        with Server(providers=[self.provider], isolate=True) as S:
+            with Context('pva', conf=S.conf(), useenv=False) as C:
+                result = C.get('testget:coth', timeout=self.timeout)
+                self.assertAlmostEqual(float(result), 42.0)

--- a/src/p4p/test/test_sharedpv.py
+++ b/src/p4p/test/test_sharedpv.py
@@ -420,3 +420,62 @@ class TestFirstLast(RefTestCase):
 
                 _log.debug('CLOSE')
                 self.assertFalse(self.H.conn)
+
+
+class TestOnGet(RefTestCase):
+    maxDiff = 1000
+    timeout = 1.0
+
+    class OnGetHandler(object):
+        def __init__(self):
+            self.called = threading.Event()
+
+        def onGet(self, pv, op):
+            self.called.set()
+            op.done(value=pv.current())
+
+    class _DummyHandler(object):
+        pass
+
+    def setUp(self):
+        super(TestOnGet, self).setUp()
+
+        self.handler = self.OnGetHandler()
+        self.pv = SharedPV(handler=self.handler, nt=NTScalar('d'), initial=42.0)
+        self.pv_nodummy = SharedPV(handler=self._DummyHandler(), nt=NTScalar('d'), initial=42.0)
+        self.sprov = StaticProvider("testget")
+        self.sprov.add('testget:pv', self.pv)
+        self.sprov.add('testget:nodummy', self.pv_nodummy)
+        self.server = Server(providers=[self.sprov], isolate=True)
+        _log.debug('Server Conf: %s', self.server.conf())
+
+    def tearDown(self):
+        self.server.stop()
+        _defaultWorkQueue.sync()
+        R = [weakref.ref(r) for r in (self.server, self.sprov, self.pv, self.pv._whandler, self.pv._handler)]
+        r = None
+        del self.server
+        del self.sprov
+        del self.pv
+        del self.pv_nodummy
+        del self.handler
+        gc.collect()
+        R = [r() for r in R]
+        self.assertListEqual(R, [None] * len(R))
+        super(TestOnGet, self).tearDown()
+
+    def test_onget_called(self):
+        with Context('pva', conf=self.server.conf(), useenv=False) as ctxt:
+            result = ctxt.get('testget:pv', timeout=self.timeout)
+            self.assertTrue(self.handler.called.wait(timeout=self.timeout))
+
+    def test_onget_done_value(self):
+        with Context('pva', conf=self.server.conf(), useenv=False) as ctxt:
+            result = ctxt.get('testget:pv', timeout=self.timeout)
+            self.assertAlmostEqual(float(result), 42.0)
+
+    def test_onget_no_handler(self):
+        # handler has no onGet — should return current value without error (backward compat)
+        with Context('pva', conf=self.server.conf(), useenv=False) as ctxt:
+            result = ctxt.get('testget:nodummy', timeout=self.timeout)
+            self.assertAlmostEqual(float(result), 42.0)

--- a/src/p4p/test/test_sharedpv.py
+++ b/src/p4p/test/test_sharedpv.py
@@ -479,3 +479,16 @@ class TestOnGet(RefTestCase):
         with Context('pva', conf=self.server.conf(), useenv=False) as ctxt:
             result = ctxt.get('testget:nodummy', timeout=self.timeout)
             self.assertAlmostEqual(float(result), 42.0)
+
+    def test_onget_error(self):
+        class ErrorHandler(object):
+            def onGet(self, pv, op):
+                op.done(error='hardware read failed')
+
+        pv_err = SharedPV(handler=ErrorHandler(), nt=NTScalar('d'), initial=0.0)
+        sprov_err = StaticProvider("testget_err")
+        sprov_err.add('testget:err', pv_err)
+        with Server(providers=[sprov_err], isolate=True) as server_err:
+            with Context('pva', conf=server_err.conf(), useenv=False) as ctxt:
+                with self.assertRaises(RemoteError):
+                    ctxt.get('testget:err', timeout=self.timeout)

--- a/src/pvxs_sharedpv.cpp
+++ b/src/pvxs_sharedpv.cpp
@@ -112,4 +112,129 @@ void detachCleanup(const std::shared_ptr<server::ExecOp> &op)
     op->onCancel(nullptr);
 }
 
+struct GetInterceptSource : public server::Source {
+    std::string pvname;
+    server::SharedPV pv;
+    // handler is borrowed — caller (Cython StaticProvider) maintains lifetime
+    PyObject* handler;
+
+    GetInterceptSource(const std::string& name_, server::SharedPV& pv_, PyObject* handler_)
+        : pvname(name_), pv(pv_), handler(handler_)
+    {}
+
+    virtual ~GetInterceptSource() {}
+
+    virtual void onSearch(server::Source::Search& op) override {
+        for(auto& name : op) {
+            if(name.name() == pvname) {
+                PyLock L;
+                if(pv.isOpen())
+                    name.claim();
+            }
+        }
+    }
+
+    virtual void onCreate(std::unique_ptr<server::ChannelControl>&& op) override {
+        // Convert to shared_ptr so we can capture in lambdas
+        std::shared_ptr<server::ChannelControl> ctrl(std::move(op));
+
+        ctrl->onOp([this, ctrl](std::unique_ptr<server::ConnectOp>&& connectop) {
+            auto cop = std::shared_ptr<server::ConnectOp>(std::move(connectop));
+
+            // Tell client what data type this PV provides
+            {
+                PyLock L;
+                if(!pv.isOpen()) {
+                    cop->error("PV not open");
+                    return;
+                }
+                Value proto;
+                {
+                    PyUnlock U;
+                    proto = pv.fetch();
+                }
+                cop->connect(proto);
+            }
+
+            // GET handler
+            cop->onGet([this](std::unique_ptr<server::ExecOp>&& gop) {
+                PyLock L;
+                std::shared_ptr<server::ExecOp> op(std::move(gop));
+
+                if(!PyObject_HasAttrString(handler, "onGet")) {
+                    // CPP-03: no onGet — return current PV value (backward compat)
+                    Value current;
+                    {
+                        PyUnlock U;
+                        current = pv.fetch();
+                        op->reply(current);
+                    }
+                    return;
+                }
+
+                PyRef pyop(ServerOperation_wrap(op, Value{}));
+
+                auto ret(PyRef::allownull(PyObject_CallMethod(handler, "onGet", "O", pyop.obj)));
+                if(PyErr_Occurred()) {
+                    PySys_WriteStderr("Unhandled Exception %s:%d\n", __FILE__, __LINE__);
+                    PyErr_Print();
+                    PyErr_Clear();
+                    op->error("Internal Error on Remote end");
+                }
+            });
+
+            // PUT handler — delegate to Python handler.put
+            cop->onPut([this](std::unique_ptr<server::ExecOp>&& rawop, Value&& val) {
+                PyLock L;
+                std::shared_ptr<server::ExecOp> op(std::move(rawop));
+                PyRef pyop(ServerOperation_wrap(op, val));
+
+                auto ret(PyRef::allownull(PyObject_CallMethod(handler, "put", "O", pyop.obj)));
+                if(PyErr_Occurred()) {
+                    PySys_WriteStderr("Unhandled Exception %s:%d\n", __FILE__, __LINE__);
+                    PyErr_Print();
+                    PyErr_Clear();
+                    op->error("Internal Error on Remote end");
+                }
+            });
+        });
+
+        // RPC handler — delegate to Python handler.rpc
+        ctrl->onRPC([this](std::unique_ptr<server::ExecOp>&& rawop, Value&& val) {
+            PyLock L;
+            std::shared_ptr<server::ExecOp> op(std::move(rawop));
+            PyRef pyop(ServerOperation_wrap(op, val));
+
+            auto ret(PyRef::allownull(PyObject_CallMethod(handler, "rpc", "O", pyop.obj)));
+            if(PyErr_Occurred()) {
+                PySys_WriteStderr("Unhandled Exception %s:%d\n", __FILE__, __LINE__);
+                PyErr_Print();
+                PyErr_Clear();
+                op->error("Internal Error on Remote end");
+            }
+        });
+
+        // Subscribe handler — deliver current value on connect
+        ctrl->onSubscribe([this](std::unique_ptr<server::MonitorSetupOp>&& mop) {
+            PyLock L;
+            if(!pv.isOpen()) {
+                mop->error("PV not open");
+                return;
+            }
+            Value proto;
+            {
+                PyUnlock U;
+                proto = pv.fetch();
+            }
+            auto sub = mop->connect(proto);
+            sub->post(proto);
+        });
+    }
+};
+
+std::shared_ptr<server::Source> attachGetHandler(const std::string& name, server::SharedPV& pv, PyObject* handler)
+{
+    return std::make_shared<GetInterceptSource>(name, pv, handler);
+}
+
 }

--- a/src/pvxs_sharedpv.cpp
+++ b/src/pvxs_sharedpv.cpp
@@ -1,4 +1,7 @@
 
+#include <algorithm>
+#include <mutex>
+#include <vector>
 #include <sstream>
 
 #include "p4p.h"
@@ -112,11 +115,18 @@ void detachCleanup(const std::shared_ptr<server::ExecOp> &op)
     op->onCancel(nullptr);
 }
 
-struct GetInterceptSource : public server::Source {
+struct GetInterceptSource : public server::Source,
+                             public std::enable_shared_from_this<GetInterceptSource> {
     std::string pvname;
     server::SharedPV pv;
     // handler is borrowed — caller (Cython StaticProvider) maintains lifetime
     PyObject* handler;
+
+    // Active channels, kept alive here so PVXS can dispatch callbacks.
+    // Removed via onClose when a client disconnects; all remaining are
+    // cleared when this source is destroyed (after server.stop()).
+    std::mutex channels_lock;
+    std::vector<std::shared_ptr<server::ChannelControl>> channels;
 
     GetInterceptSource(const std::string& name_, server::SharedPV& pv_, PyObject* handler_)
         : pvname(name_), pv(pv_), handler(handler_)
@@ -135,10 +145,28 @@ struct GetInterceptSource : public server::Source {
     }
 
     virtual void onCreate(std::unique_ptr<server::ChannelControl>&& op) override {
-        // Convert to shared_ptr so we can capture in lambdas
-        std::shared_ptr<server::ChannelControl> ctrl(std::move(op));
+        auto ctrl = std::shared_ptr<server::ChannelControl>(std::move(op));
 
-        ctrl->onOp([this, ctrl](std::unique_ptr<server::ConnectOp>&& connectop) {
+        // Use weak_ptr so the onClose callback doesn't extend our lifetime,
+        // and so it's a no-op if we're already being destroyed.
+        std::weak_ptr<GetInterceptSource> weak_self(shared_from_this());
+        server::ChannelControl* raw_ctrl = ctrl.get();
+
+        ctrl->onClose([weak_self, raw_ctrl](const std::string&) {
+            if(auto self = weak_self.lock()) {
+                std::lock_guard<std::mutex> lock(self->channels_lock);
+                auto& ch = self->channels;
+                ch.erase(
+                    std::remove_if(ch.begin(), ch.end(),
+                        [raw_ctrl](const std::shared_ptr<server::ChannelControl>& c) {
+                            return c.get() == raw_ctrl;
+                        }),
+                    ch.end()
+                );
+            }
+        });
+
+        ctrl->onOp([this](std::unique_ptr<server::ConnectOp>&& connectop) {
             auto cop = std::shared_ptr<server::ConnectOp>(std::move(connectop));
 
             // Tell client what data type this PV provides
@@ -229,6 +257,13 @@ struct GetInterceptSource : public server::Source {
             auto sub = mop->connect(proto);
             sub->post(proto);
         });
+
+        // Store ctrl to keep the ChannelControl alive while the channel is open.
+        // This avoids a self-referential shared_ptr cycle (ctrl captured in its own
+        // lambda) that prevents cleanup on some platforms.  Removed via onClose above,
+        // or flushed when this source is destroyed.
+        std::lock_guard<std::mutex> lock(channels_lock);
+        channels.push_back(std::move(ctrl));
     }
 };
 


### PR DESCRIPTION
## Summary

- Adds `onGet(self, pv, op)` to the `Handler` interface, called when a client issues `cxt.get()` on a SharedPV
- GET interception is implemented via a custom `GetInterceptSource` C++ source that uses `ChannelControl::onOp()` → `ConnectOp::onGet()`, operating below the SharedPV layer
- The `ExecOp` is wrapped as an existing `ServerOperation` object; handlers call `op.done(value=...)` or `op.done(error=...)` to respond
- Backward compatible: handlers without `onGet` preserve the default PVXS behavior (return current posted value)
- Works across thread, asyncio, and cothread backends via the existing `_exec` dispatch mechanism — no backend changes required
- `SharedPV.get` decorator property added for functional-style registration (mirrors `@pv.put` / `@pv.rpc`)

## Changes

| File | What changed |
|------|-------------|
| `src/pvxs_sharedpv.cpp` | `GetInterceptSource` custom Source; registered at higher priority than StaticSource when handler has `onGet` |
| `src/p4p/_p4p.pyx` | Wire `GetInterceptSource` into `StaticProvider.add()` and `Server.__init__` |
| `src/p4p.h` | Declarations for new C++ helpers |
| `src/p4p/server/raw.py` | `Handler.onGet` docstring; `_WrapHandler` conditionally binds instance-level `onGet`; `SharedPV.get` decorator |
| `src/p4p/test/test_sharedpv.py` | `TestOnGet`: GET triggers onGet, value delivery, error delivery, backward compat, ref-leak checks |
| `src/p4p/test/asynciotest.py` | `TestOnGet`: sync and `async def onGet` in asyncio backend |
| `src/p4p/test/cothreadtest.py` | `TestOnGet`: cothread backend (auto-skips when cothread absent) |
| `documentation/server.rst` | `.. automethod:: onGet` in Handler API reference; hardware-read example |

## Usage

```python
from p4p.server.thread import SharedPV, Handler
from p4p.nt import NTScalar

class MyHandler(Handler):
    def onGet(self, pv, op):
        # called on every cxt.get() — read hardware here
        value = read_hardware_register()
        op.done(value=value)

pv = SharedPV(handler=MyHandler(), nt=NTScalar('d'), initial=0.0)

# or with the decorator:
pv = SharedPV(nt=NTScalar('d'), initial=0.0)

@pv.get
def handle_get(pv, op):
    op.done(value=read_hardware_register())
```

## Test plan

- [ ] `python -m pytest src/p4p/test/test_sharedpv.py::TestOnGet -v` — thread backend: invocation, value, error, backward compat, ref leaks
- [ ] `python -m pytest src/p4p/test/test_asyncio.py::TestOnGet -v` — asyncio backend: sync and async handlers
- [ ] `python -m pytest src/p4p/test/test_cothread.py::TestOnGet -v` — cothread backend (skipped if cothread absent)