### PR TITLE
asLib: fix ValueError when a channel maps to ASG with no ASG(DEFAULT)

### DIFF
--- a/src/p4p/asLib/__init__.py
+++ b/src/p4p/asLib/__init__.py
@@ -166,7 +166,10 @@ class Engine(object):
             self._uag = uag
             self._hag = hag
             self._asg = asg
-            self._asg_DEFAULT = asg.get('DEFAULT', [])
+            # values of self._asg are (rules, inputs) 2-tuples; the fallback
+            # must be unpackable the same way (see create()), so an empty ruleset
+            # is ([], {}) rather than a bare list.
+            self._asg_DEFAULT = asg.get('DEFAULT', ([], {}))
             self._hag_addr = hag_addr
 
         self._recompute()


### PR DESCRIPTION
self._asg values are (rules, inputs) 2-tuples, but the DEFAULT fallback was a
bare list: self._asg_DEFAULT = asg.get('DEFAULT', []). In create(),
`rules, inputs = self._asg.get(group, self._asg_DEFAULT)` then executed
`rules, inputs = []` -> ValueError whenever a PV's ASG was absent and no
ASG(DEFAULT) block was defined. This runs outside the try/except in create(),
so the channel was left restrictive (or the error surfaced through asTest),
wrongly denying access to every default-group channel.

Use an unpackable empty ruleset ([], {}) as the fallback.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
