### PR TITLE
client/asyncio: break after subscription completion to avoid pop() on None

### DIFF
--- a/src/p4p/client/asyncio.py
+++ b/src/p4p/client/asyncio.py
@@ -401,6 +401,7 @@ class Subscription(object):
                         if self._notify_disconnect:
                             E = Finished()
                             await self._cb(E)
+                        break  # queue drained; do not loop back and pop() from None
 
 
         except asyncio.CancelledError:


### PR DESCRIPTION
After a subscription completed, _handle set self._S = None but fell through
into the enclosing `while self._run:` loop (unlike the cothread client, which
breaks). The next iteration ran `S = self._S` (None) then `S.pop()` ->
AttributeError, caught by the bare except and logged as
"Error processing Subscription event" with a traceback on every normal monitor
completion. Data was delivered correctly, but each finishing monitor emitted a
spurious error.

Break out of the loop after handling completion.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
