### PR TITLE
nt/common: fix Python-2 _dt2posix using * instead of + for microseconds

### DIFF
--- a/src/p4p/nt/common.py
+++ b/src/p4p/nt/common.py
@@ -9,7 +9,7 @@ if hasattr(datetime, 'timestamp'):
 else: # py 2.x
     from calendar import timegm as _timegm
     def _dt2posix(dt):
-        return _timegm(dt.timetuple()) * dt.microsecond*1e-6
+        return _timegm(dt.timetuple()) + dt.microsecond*1e-6
 
 # common sub-structs
 timeStamp = Type(id='time_t', spec=[


### PR DESCRIPTION
The py2 fallback computed `_timegm(dt.timetuple()) * dt.microsecond*1e-6`,
multiplying the epoch seconds by the fractional part (and yielding 0 whenever
microsecond==0) instead of adding the sub-second offset. Only reachable on
Python 2 (py3 uses datetime.timestamp), but the result there was grossly
wrong.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
