### PR TITLE
disect: import callable fnmatch, not the glob-reexported module

### DIFF
--- a/src/p4p/disect.py
+++ b/src/p4p/disect.py
@@ -6,7 +6,7 @@ import sys
 import gc
 import inspect
 import time
-from glob import fnmatch
+from fnmatch import fnmatch
 try:
     from types import InstanceType
 except ImportError:  # py3


### PR DESCRIPTION
`from glob import fnmatch` binds the fnmatch *module* (glob re-exports it), so
`fnmatch(str(K), name)` in gcfind() raised
`TypeError: 'module' object is not callable`, making the helper unusable.
Import the function directly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
