### PR TITLE
gw: fix `poke` stats PV handler crashing on update_stats() with no norm

### DIFF
--- a/src/p4p/gw.py
+++ b/src/p4p/gw.py
@@ -309,7 +309,7 @@ class GWStats(object):
         for handler in self.handlers:
             handler.sweep()
 
-    def update_stats(self, norm):
+    def update_stats(self, norm=1.0):
         T0 = time.time()
         self.refsPV.post(listRefs())
 


### PR DESCRIPTION
update_stats(self, norm) required a positional `norm` (used to normalize the
byte counters into rates via provider.report(norm)/Server_report(server,
norm)). The `poke` SharedPV put-handler called self.update_stats() with no
argument, so a client Put to the poke PV always raised
`TypeError: update_stats() missing 1 required positional argument: 'norm'`,
which the worker turned into an op error -- the poke never refreshed stats.

Default norm=1.0, matching the Cython report(float norm=1.0) default, so a
manual poke reports un-normalized totals.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
