### PR TITLE
nt/ndarray: don't mutate caller's attrib dict in NTNDArray.wrap

### DIFF
--- a/src/p4p/nt/ndarray.py
+++ b/src/p4p/nt/ndarray.py
@@ -147,7 +147,9 @@ class NTNDArray(NTBase):
     def wrap(self, value, **kws):
         """Wrap numpy.ndarray as Value
         """
-        attrib = getattr(value, 'attrib', None) or kws.pop('attrib', None) or {}
+        # copy: the block below may inject 'ColorMode', and attrib may be the
+        # caller's own ntndarray.attrib dict (aliasing would mutate their object)
+        attrib = dict(getattr(value, 'attrib', None) or kws.pop('attrib', None) or {})
 
         value = numpy.asarray(value) # loses any special/augmented attributes
         dims = value.shape


### PR DESCRIPTION
wrap() bound `attrib` directly to the array's own `.attrib` dict when it was
non-empty, then wrote `attrib['ColorMode'] = ...` into it. Wrapping an
ntndarray thus injected ColorMode back into the caller's object, and wrapping
the same array twice saw the earlier injection. Copy into a fresh dict before
mutating.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
