### PR TITLE
asLib/pvlist: fix AssertionError on ALLOW rule containing a capture group

### DIFF
--- a/src/p4p/asLib/pvlist.py
+++ b/src/p4p/asLib/pvlist.py
@@ -105,6 +105,7 @@ class PVList(object):
                     asl = int(parts[1] if len(parts)>1 else '0')
 
                     allow[pattern] = (None, asg, asl)
+                    ngroups += C.groups # account for the pattern's own capture groups
 
                 else:
                     raise RuntimeError("Unknown command: %s"%cmd)


### PR DESCRIPTION
The ALLOW branch advanced `ngroups` by 1 (for the wrapper group that
_re_join adds) but, unlike the ALIAS branch, never added the pattern's own
capture-group count `C.groups`. The final invariant
`assert self._allow_pat.groups+1==ngroups` then failed for any ALLOW pattern
with a capture group (e.g. `.*(foo|bar).* ALLOW`), aborting the whole pvlist
load and taking the gateway down via readnproc -> sys.exit(1). It also left
the per-rule group indices in `_allow_groups` misaligned for subsequent rules.

Mirror the ALIAS branch by adding `ngroups += C.groups`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
