### PR TITLE
rpc: fix list/tuple return-type spec (was testing builtin `type`)

### DIFF
--- a/src/p4p/rpc.py
+++ b/src/p4p/rpc.py
@@ -45,7 +45,7 @@ def rpc(rtype=None):
     wrap = None
     if rtype is None or isinstance(rtype, Type):
         pass
-    elif isinstance(type, (list, tuple)):
+    elif isinstance(rtype, (list, tuple)):
         rtype = Type(rtype)
     elif hasattr(rtype, 'type'):  # eg. one of the NT* helper classes
         wrap = rtype.wrap


### PR DESCRIPTION
The branch handling an rtype given as a list/tuple checked `isinstance(type,
(list, tuple))` -- the builtin `type`, never an instance of list/tuple -- so it
was dead. A list/tuple rtype fell through to `hasattr(rtype, 'type')` (False)
and then `raise TypeError("Not supported")`, breaking the documented form
`@rpc([('result', 'i')])` at class-definition time.

Test `rtype` instead of `type`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
