### PR TITLE
client: fix Subscription.done crash and drop unbacked .empty property

### DIFF
--- a/src/p4p/client/asyncio.py
+++ b/src/p4p/client/asyncio.py
@@ -340,12 +340,8 @@ class Subscription(object):
     @property
     def done(self):
         'Has all data for this subscription been received?'
-        return self._S is None or self._S.done()
+        return self._S is None or self._S.complete()
 
-    @property
-    def empty(self):
-        'Is data pending in event queue?'
-        return self._S is None or self._S.empty()
 
     async def wait_closed(self):
         """Wait until subscription is closed.

--- a/src/p4p/client/cothread.py
+++ b/src/p4p/client/cothread.py
@@ -260,12 +260,8 @@ class Subscription(object):
     @property
     def done(self):
         'Has all data for this subscription been received?'
-        return self._S is None or self._S.done()
+        return self._S is None or self._S.complete()
 
-    @property
-    def empty(self):
-        'Is data pending in event queue?'
-        return self._S is None or self._S.empty()
 
     def _event(self):
         if self._S is not None:

--- a/src/p4p/client/thread.py
+++ b/src/p4p/client/thread.py
@@ -77,12 +77,8 @@ class Subscription(object):
     @property
     def done(self):
         'Has all data for this subscription been received?'
-        return self._S is None or self._S.done()
+        return self._S is None or self._S.complete()
 
-    @property
-    def empty(self):
-        'Is data pending in event queue?'
-        return self._S is None or self._S.empty()
 
     def _event(self):
         try:


### PR DESCRIPTION
Subscription._S is a raw.Subscription (a _p4p.ClientMonitor subclass).
ClientMonitor exposes only close() and pop(); it has no done() or empty().
raw.Subscription instead stores a plain bool attribute `self.done = False`
(exposed via complete()).

- `sub.done` evaluated `self._S.done()`, i.e. called the bool `False`, raising
  `TypeError: 'bool' object is not callable` on every live subscription. Fixed
  to call `self._S.complete()`.
- `sub.empty` evaluated `self._S.empty()`, which does not exist ->
  AttributeError. There is no way to query queue-emptiness from the extension
  (pop() returns None when empty), so the non-functional property is removed.

Applies to the thread, cothread, and asyncio clients identically.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
