### PR TITLE
Security: fix ACL privilege escalation + hardening

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Python
 
 on: [push, pull_request, workflow_dispatch]
 
+# Least privilege: no job needs to write back to the repo. Publishing to PyPI
+# uses TWINE_* secrets, not GITHUB_TOKEN, so read access is sufficient here.
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -2,6 +2,10 @@ name: Makefile
 
 on: [push, pull_request, workflow_dispatch]
 
+# Least privilege: this workflow only builds/tests, it never writes to the repo.
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash

--- a/src/p4p/_p4p.pyx
+++ b/src/p4p/_p4p.pyx
@@ -53,10 +53,10 @@ cdef extern from "<p4p.h>" namespace "p4p":
     void disconnectDynamic(const shared_ptr[server.Source]& src) except+
 
     # pvxs_client.cpp
-    void opHandler[Builder](Builder& builder, object handler)
-    void opBuilder[Builder](Builder& builder, object handler)
-    void opEvent(client.MonitorBuilder& builder, object handler)
-    object monPop(const shared_ptr[client.Subscription]& mon) with gil
+    void opHandler[Builder](Builder& builder, object handler) except+
+    void opBuilder[Builder](Builder& builder, object handler) except+
+    void opEvent(client.MonitorBuilder& builder, object handler) except+
+    object monPop(const shared_ptr[client.Subscription]& mon) except+ with gil
 
 cimport numpy # must cimport after p4p.h is included
 

--- a/src/p4p/asLib/__init__.py
+++ b/src/p4p/asLib/__init__.py
@@ -240,7 +240,9 @@ class Engine(object):
 
         with self._lock:
 
-            uags = self._uag.get(user, set())
+            # copy the stored set; |= below is in-place and would otherwise
+            # permanently merge client-asserted roles into the shared UAG state
+            uags = set(self._uag.get(user, ()))
             for role in roles:
                 uags |= self._uag.get('role/'+role, set())
             hags = self._hag_addr.get(host, set())


### PR DESCRIPTION
Security review of p4p. One real vulnerability plus three low-severity hardening items.

### HIGH — Privilege escalation via in-place mutation of shared UAG state
`src/p4p/asLib/__init__.py` — `Engine.create()` did `uags = self._uag.get(user, set())` then `uags |= …role…`. Because `.get()` returns the *stored* set, the in-place `|=` permanently merged client-asserted (forgeable, under default `ca` auth) roles into that account's process-global group membership. A single connection could permanently elevate an account; every later evaluation of that account — including role-less sessions from other hosts and the periodic `_recompute()` — then inherited the escalation. Fixed by copying the set before the union.

Reproduced against the compiled `Engine`: unpatched, `_uag['alice']` goes `['OPS'] → ['ADMINS','OPS']` and stays; patched, it stays `['OPS']`.

### Low — hardening
- **CI least-privilege:** add `permissions: contents: read` to `build.yml`/`ci-scripts.yml` (publish uses TWINE secrets, not the token).
- **Native `except+`:** `monPop`/`opHandler`/`opBuilder`/`opEvent` in `_p4p.pyx` lacked the exception spec every sibling has; an unexpected C++ exception (e.g. `std::bad_alloc` from `pop()`) would `std::terminate` the interpreter instead of raising.
- **`dynamic_cast` guard** in `pvxs_source.cpp::disconnectDynamic` (defense-in-depth against a future NULL deref).

### Verification
Built against `epicscorelibs` 7.0.10 / `pvxslibs` 1.5.2 — the native changes compile cleanly and the full test suite passes (157 tests, 2 skipped).